### PR TITLE
Remove enable services_env_parameter by default

### DIFF
--- a/content/1.get-started/30.create-new-project.md
+++ b/content/1.get-started/30.create-new-project.md
@@ -19,7 +19,7 @@ To spin up the project locally run:
       ddev start
       ddev composer install
       ddev drush site-install -y --account-pass=admin --site-name='lupus_decoupled' standard
-      ddev drush pm-enable lupus_decoupled, services_env_parameter -y
+      ddev drush pm-enable lupus_decoupled -y
       # Configure lupus-decoupled frontend base URL
       ddev drush config:set lupus_decoupled_ce_api.settings frontend_base_url https://lupus-nuxt.ddev.site -y
       # Login and get started adding some test-nodes


### PR DESCRIPTION
ddev drush pm-enable lupus_decoupled, services_env_parameter -y

In PmCommands.php line 329:
                                                                                                                    
  Unable to install modules lupus_decoupled, services_env_parameter due to missing modules services_env_parameter.  