### PR TITLE
fix project template repo url in 'Local setup with ddev' instructions

### DIFF
--- a/content/1.get-started/30.create-new-project.md
+++ b/content/1.get-started/30.create-new-project.md
@@ -16,8 +16,8 @@ Requirements:
 
 To spin up the project locally run:
 
-      git clone git@github.com:drunomics/lupus-decoupled-website.git
-      cd lupus-decoupled-website
+      git clone git@github.com:drunomics/lupus-decoupled-project.git
+      cd lupus-decoupled-project
       ddev start
       ddev composer install
       ddev drush site-install -y --account-pass=admin --site-name='lupus_decoupled' standard


### PR DESCRIPTION
In the documentation, the steps to spin up the project locally include [website repo](https://github.com/drunomics/lupus-decoupled-website) url instead of [project template](https://github.com/drunomics/lupus-decoupled-project) repo url.
https://github.com/drunomics/lupus-decoupled-website/blob/27acd59ccd16ec6a9b7db207a0e4a84a044f5c2d/content/1.get-started/30.create-new-project.md?plain=1#L19-L20 This pr fixes it.