### PR TITLE
Custom Elements: grammar: singular/plural

### DIFF
--- a/content/4.drupal/20.custom-elements.md
+++ b/content/4.drupal/20.custom-elements.md
@@ -52,7 +52,7 @@ Besides slot, an element may contain any number of attributes, which are key val
 
 ### Cache Metadata
 
-Custom elements integrate with Drupal's [cache API](https://www.drupal.org/docs/8/api/cache-api/cacheabledependencyinterface-friends), thus allows element to define their caching dependencies via cache tags and their cache context. It implements the `CacheableDependencyInterface`, so it's cache dependencies can be easily added as usual, for example entities:
+Custom elements integrate with Drupal's [cache API](https://www.drupal.org/docs/8/api/cache-api/cacheabledependencyinterface-friends), by allowing to define their caching dependencies via cache tags and their cache context. They implement the `CacheableDependencyInterface`, so their cache dependencies can be easily added as usual, for example entities:
 
     <?php
       $custom_element->addCacheableDependency($entity);


### PR DESCRIPTION
It's minor, but I'm adding a PR instead of directly pushing because I'm not 100% of what was/is meant.

Current:
> Custom elements integrates [...] this allows element to define their caching dependencies via cache tags and their cache context.

IF "Custom elements" are "things", this should be plural -> "Custom elements [...] this allows  _themselves???_ to define..." -> changed to
>  Custom elements integrates [...] by allowing to define ...

^^
This is the PR

---

IF "Custom Elements" was meant the module, this should be singular.  
> "Custom elements **integrates** with Drupal [...]  allows element**s** to define their ..."

But I don't think that's the case.