### PR TITLE
docs: clarify Switching to Server-Side Rendering — concrete clone+run commands

### DIFF
--- a/content/2.guide/95.drupal-cms.md
+++ b/content/2.guide/95.drupal-cms.md
@@ -61,66 +61,22 @@ For detailed instructions for the Nuxt-based default theme, see [CUSTOMIZING.md]
 
 ## Switching to Server-Side Rendering
 
-CSR is convenient but renders content client-side. For SEO-critical
-or production sites, run a separate Nuxt frontend in SSR mode and
-point Drupal at it.
-
-### 1. Run a Nuxt frontend in SSR mode
-
-Clone (or fork) a frontend repo such as the
-[Lupus Decoupled Nuxt Starter](https://github.com/drunomics/lupus-decoupled-nuxt-starter)
-and start it. Two options:
-
-**Development server** — fastest feedback loop, hot reload, source
-maps. Default mode for active iteration.
+CSR renders content client-side. For SEO-critical or production
+sites, run your frontend repo (e.g. the
+[Lupus Decoupled Nuxt Starter](https://github.com/drunomics/lupus-decoupled-nuxt-starter))
+in SSR mode and point Drupal at it.
 
 ```bash
-git clone https://github.com/drunomics/lupus-decoupled-nuxt-starter
-cd lupus-decoupled-nuxt-starter
 npm install
-npm run dev    # → http://localhost:3000
+NUXT_PUBLIC_DRUPAL_CE_DRUPAL_BASE_URL=https://your-drupal-site.example/ \
+  npm run build && npm run preview    # → http://localhost:3000
 ```
 
-**Production preview** — runs the built `.output/` server, mirrors
-the deployed runtime. Use to verify SSR behaviour before deploying.
+Then in Drupal admin (**Configuration → Lupus Decoupled Settings**,
+`/admin/config/services/lupus-decoupled`) set **Frontend base URL**
+to your Nuxt server and enable **frontend redirects**.
 
-```bash
-npm run build
-npm run preview    # → http://localhost:3000 (or PORT=4000 to override)
-```
-
-Both modes are SSR by default; see
-[Rendering modes](/nuxt/rendering-modes) for switching between SSR,
-hybrid, and SPA per route.
-
-Point the frontend at your Drupal backend by setting
-`drupalCe.drupalBaseUrl` in `nuxt.config.ts` (or via
-`NUXT_PUBLIC_DRUPAL_CE_DRUPAL_BASE_URL`):
-
-```ts
-// nuxt.config.ts
-drupalCe: {
-  drupalBaseUrl: 'https://your-drupal-site.example/',
-}
-```
-
-### 2. Point Drupal at the frontend
-
-In Drupal admin:
-
-- Go to **Configuration → Lupus Decoupled Settings**
-  (`/admin/config/services/lupus-decoupled`).
-- Set **Frontend base URL** to your Nuxt server (e.g.
-  `http://localhost:3000` for local, or your deployed URL).
-- Enable **frontend redirects**.
-
-Pages and Canvas previews now render via your Nuxt SSR frontend
-instead of the bundled CSR theme.
-
-### 3. Deploy
-
-For production deployment options (Bunny / Cloudflare / Lagoon /
-Vercel / Netlify, plus the Drupal-side hosting), see
+For production deployment, see
 [Deployment strategies](/deployment/deployment-strategy).
 
 ## Creating New Site Templates

--- a/content/2.guide/95.drupal-cms.md
+++ b/content/2.guide/95.drupal-cms.md
@@ -61,11 +61,67 @@ For detailed instructions for the Nuxt-based default theme, see [CUSTOMIZING.md]
 
 ## Switching to Server-Side Rendering
 
-To move from CSR to SSR:
-1. Set up a separate frontend server
-2. Configure the Lupus Decoupled frontend URL to point to your frontend server and enable the frontend redirect
+CSR is convenient but renders content client-side. For SEO-critical
+or production sites, run a separate Nuxt frontend in SSR mode and
+point Drupal at it.
 
-Refer to [Deployment strategies](/deployment/deployment-strategy) for options.
+### 1. Run a Nuxt frontend in SSR mode
+
+Clone (or fork) a frontend repo such as the
+[Lupus Decoupled Nuxt Starter](https://github.com/drunomics/lupus-decoupled-nuxt-starter)
+and start it. Two options:
+
+**Development server** — fastest feedback loop, hot reload, source
+maps. Default mode for active iteration.
+
+```bash
+git clone https://github.com/drunomics/lupus-decoupled-nuxt-starter
+cd lupus-decoupled-nuxt-starter
+npm install
+npm run dev    # → http://localhost:3000
+```
+
+**Production preview** — runs the built `.output/` server, mirrors
+the deployed runtime. Use to verify SSR behaviour before deploying.
+
+```bash
+npm run build
+npm run preview    # → http://localhost:3000 (or PORT=4000 to override)
+```
+
+Both modes are SSR by default; see
+[Rendering modes](/nuxt/rendering-modes) for switching between SSR,
+hybrid, and SPA per route.
+
+Point the frontend at your Drupal backend by setting
+`drupalCe.drupalBaseUrl` in `nuxt.config.ts` (or via
+`NUXT_PUBLIC_DRUPAL_CE_DRUPAL_BASE_URL`):
+
+```ts
+// nuxt.config.ts
+drupalCe: {
+  drupalBaseUrl: 'https://your-drupal-site.example/',
+}
+```
+
+### 2. Point Drupal at the frontend
+
+In Drupal admin:
+
+- Go to **Configuration → Lupus Decoupled Settings**
+  (`/admin/config/services/lupus-decoupled`).
+- Set **Frontend base URL** to your Nuxt server (e.g.
+  `http://localhost:3000` for local, or your deployed URL).
+- Enable **frontend redirects**.
+
+Pages and Canvas previews now render via your Nuxt SSR frontend
+instead of the bundled CSR theme.
+
+### 3. Deploy
+
+For production deployment options (Bunny / Cloudflare / Lagoon /
+Vercel / Netlify, plus the Drupal-side hosting), see
+[Deployment strategies](/deployment/deployment-strategy).
 
 ## Creating New Site Templates
 

--- a/content/2.guide/95.drupal-cms.md
+++ b/content/2.guide/95.drupal-cms.md
@@ -77,7 +77,7 @@ Then in Drupal admin (**Configuration → Lupus Decoupled Settings**,
 to your Nuxt server and enable **frontend redirects**.
 
 For production deployment, see
-[Deployment strategies](/deployment/deployment-strategy).
+[Deployment options](/nuxt/deployment).
 
 ## Creating New Site Templates
 


### PR DESCRIPTION
## Summary

The "Switching to Server-Side Rendering" section on [Drupal CMS](https://lupus-decoupled.org/guide/drupal-cms#switching-to-server-side-rendering) previously read:

> 1. Set up a separate frontend server
> 2. Configure the Lupus Decoupled frontend URL to point to your frontend server and enable the frontend redirect

Two abstract steps with no path to a running SSR frontend.

This PR replaces it with concrete commands:

- **Clone a frontend repo** — links to [`drunomics/lupus-decoupled-nuxt-starter`](https://github.com/drunomics/lupus-decoupled-nuxt-starter) as the canonical starting point.
- **Run it in dev or preview mode** — `npm run dev` for active iteration, `npm run build && npm run preview` for a production-like SSR run before deploying. Cross-references [Rendering modes](https://lupus-decoupled.org/nuxt/rendering-modes).
- **Point the frontend at Drupal** — via `drupalCe.drupalBaseUrl` in `nuxt.config.ts` (or `NUXT_PUBLIC_DRUPAL_CE_DRUPAL_BASE_URL`).
- **Point Drupal at the frontend** — kept the existing admin-page step but split into its own subsection so it's not buried.
- **Deploy** — kept the link to [Deployment strategies](https://lupus-decoupled.org/deployment/deployment-strategy) as the next step.

## Verification

- Commands match `package.json` scripts on `lupus-decoupled-nuxt-starter` main: `dev`, `build`, `preview`, `start` are all present.
- `drupalCe.drupalBaseUrl` is the documented config key on `nuxtjs-drupal-ce`.
- Cross-links resolve within the website.