### PR TITLE
docs: remove chapter on messages with server renderings

### DIFF
--- a/content/2.guide/60.breadcrumbs-messages.md
+++ b/content/2.guide/60.breadcrumbs-messages.md
@@ -20,7 +20,3 @@ default components provided by the Nuxt Drupal CE Connector modules, Drupal mess
 ### Messages with static site generation
 
 When a redirect points to a statically pre-generated page, there is no API request made for the static page. For a message to be displayed, the message must be sent with the redirect response (unlike with the next page response, which is the Drupal default).
-
-### Messages with server renderings
-
-For server-rendering, messages need to be sent with the subsequent page response. If sent with the redirect response, a message is only displayed when the redirect response is handled by a client-side API request. To fix this for server-rendered redirect responses, please see [this issue](https://www.drupal.org/project/lupus_ce_renderer/issues/3467399).


### PR DESCRIPTION
My understanding is that the chapter on messages with server renderings can be removed because it was fixed by [#3467399: Messages sent with redirect responses cannot be server-rendered](https://www.drupal.org/project/lupus_ce_renderer/issues/3467399).