### PR TITLE
docs: MCD-605: Document loading Drupal JavaScript in a decoupled frontend.

### DIFF
--- a/content/3.advanced-topics/60.drupal-forms.md
+++ b/content/3.advanced-topics/60.drupal-forms.md
@@ -23,7 +23,9 @@ Generally, Drupal renders the form as usual. The resulting HTML markup is wrappe
 
 ## Rendering forms in the frontend
 
-Generally, the `drupal-form--default` component may be used to add form styles and JavaScript as needed, either generally for all forms via the default component, or individually by customizing things in a per-form component `drupal-form--{FORM-ID}`. Any Drupal CSS or JavaScript assets for the form elements won't be included in the decoupled frontend, thus the frontend needs to take care of providing suitable replacement style and scripts as necessary.
+Generally, the `drupal-form--default` component may be used to add form styles and JavaScript as needed, either generally for all forms via the default component, or individually by customizing things in a per-form component `drupal-form--{FORM-ID}`.
+
+The JavaScript libraries a form attaches - form `#states`, autocomplete, module behaviours - are emitted alongside the form markup as `<drupal-library-*>` elements, such that the frontend can load them and run the Drupal behaviours; see [Drupal JavaScript](/advanced-topics/drupal-javascript). Drupal CSS assets are not included, thus the frontend needs to take care of providing suitable replacement styles.
 
 In order to change the HTML markup of forms, the form elements need to be themed in Drupal.
 
@@ -58,8 +60,11 @@ a webforms get a custom elements API endpoint.
 
 ### Limitations
 
-Drupal JavasScript are currently not provided by the webform API response,
-thus any webform elements relying on JavaScript are missing the Drupal JavaScript.
+The Drupal JavaScript a webform element attaches is part of the webform API
+response, see [Drupal JavaScript](/advanced-topics/drupal-javascript) - so
+conditional (`#states`) elements work as they do in Drupal. Webform elements
+built on Drupal's Ajax framework or on core CSS (dialogs, off-canvas) are
+not covered by that and need frontend work.
 
 ### Confirmation types
 

--- a/content/3.advanced-topics/62.drupal-javascript.md
+++ b/content/3.advanced-topics/62.drupal-javascript.md
@@ -1,0 +1,78 @@
+---
+title: 'Drupal JavaScript'
+---
+
+## Overview
+
+Drupal attaches JavaScript libraries to the render arrays it builds - form `#states`, autocomplete, module behaviours. In a decoupled setup only the rendered markup travels to the frontend, so those attachments would be lost on the way out. To avoid that, the [Custom Elements](https://www.drupal.org/project/custom_elements) module emits every attached library as a `<drupal-library-*>` custom element next to the markup, such that a frontend can load the JavaScript and run the Drupal behaviours.
+
+::note
+Library elements are emitted by Custom Elements 3.x, in releases after 3.4.1.
+::
+
+## How does it work?
+
+Whenever Drupal converts a render array into a custom element - a [Drupal form](/advanced-topics/drupal-forms), a fallback-rendered [block](/advanced-topics/block-layout), a [Canvas](/guide/canvas) component tree - the libraries that bubbled up into the render array's `#attached` are turned into custom elements:
+
+* Library dependencies are resolved into load order by Drupal, so the frontend can load the files sequentially without knowing anything about Drupal's library graph.
+* One element is emitted per library that carries JavaScript, in that order, as a sibling preceding the markup in the same slot. Libraries contributing only CSS or settings are skipped.
+* The element name is the library name, lower-cased and with `/`, `.` and `_` replaced by `-`: `core/drupal.states` becomes `drupal-library-core-drupal-states`. The verbatim library name stays available in the `library` prop.
+* Each element carries its library's JavaScript files in the `js` prop, as `url` (root-relative, with a cache-busting version query - or absolute for external assets) plus the `attributes` Drupal would put on the `<script>` tag.
+* The merged `drupalSettings` are added to the first library element, JSON-encoded as a string so that setting keys reach the frontend verbatim.
+* Stylesheets are not emitted: the decoupled frontend brings its own styles.
+
+Example of a form response carrying two libraries:
+
+```json
+{
+  "element": "drupal-form-example-form",
+  "slots": {
+    "default": [
+      {
+        "element": "drupal-library-core-drupal",
+        "props": {
+          "library": "core/drupal",
+          "js": [{ "url": "/core/misc/drupal.js?v=11.3.13", "attributes": [] }],
+          "drupalSettings": "{\"ajaxTrustedUrl\":{\"form_action_p_4kMHZg\":true}}"
+        }
+      },
+      {
+        "element": "drupal-library-core-drupal-states",
+        "props": {
+          "library": "core/drupal.states",
+          "js": [{ "url": "/core/misc/states.js?v=11.3.13", "attributes": [] }]
+        }
+      },
+      "<form class=\"example-form\">...</form>"
+    ]
+  }
+}
+```
+
+## Frontend support
+
+Library elements are ordinary custom elements, so a frontend renders them like any other element. The component doing so should:
+
+1. Render no markup of its own - the element is a load instruction, not content.
+2. Resolve the `js` URLs against the Drupal base URL, since they are root-relative.
+3. Add them as `<script>` tags in the given order and keep execution order, so that dependencies run before dependents.
+4. Load every URL only once per page, since libraries may share files.
+5. Merge `drupalSettings` into `window.drupalSettings` before any script runs. A decoupled page has no settings `<script>` for Drupal's own `drupalSettingsLoader.js` to read, so the frontend takes that over.
+6. Call `Drupal.attachBehaviors(document.body, window.drupalSettings)` once the scripts have loaded, so the behaviours attach to the server-rendered markup.
+7. Skip a file that fails to load with a warning instead of aborting: some Drupal "JavaScript" is generated per request and may legitimately be unavailable in a decoupled context.
+
+This is a client-side concern only - there is nothing to do while server-side rendering the page.
+
+### Example: Nuxt
+
+The Nuxt connector module ships a `loadLibrary()` composable doing all of the above, paired with a renderless default component that applies to every library element. See [Drupal JS libraries](/nuxt/drupal-libraries) for the Nuxt-specific documentation.
+
+## Overriding or skipping a library
+
+Since every library gets a custom element of its own, a frontend can take over a single library by providing a component for that element name, e.g. `drupal-library-core-drupal-states` for `core/drupal.states`. On a frontend with a default-component fallback (like [Nuxt](/nuxt/default-components)), that component takes precedence over the generic one, so the library's JavaScript is never loaded. That way a library can be replaced by a native frontend implementation, or skipped entirely by rendering nothing.
+
+## Limitations
+
+* **No CSS**: libraries whose behaviour relies on Drupal core CSS (dialog, off-canvas) work, but are unstyled until the frontend provides its own styles.
+* **JavaScript-enabled behaviours only**: everything Drupal does server-side stays server-side; this only restores what Drupal would have run in the browser.
+* Only `#states`-style behaviours are verified end-to-end so far. Ajax- and dialog-based libraries are expected to need more work in a decoupled context, since they rely on Drupal's own page URLs and response formats.

--- a/content/5.nuxt/35.composables.md
+++ b/content/5.nuxt/35.composables.md
@@ -20,6 +20,8 @@ This composable exports a collection of utilities to handle Drupal content and f
 - `renderCustomElements(elements: string | object | Array)` - Renders one or multiple custom elements from JSON data
 - `resolveCustomElement(element: string)` - Resolves a custom element name to a Vue component
 
+- `loadLibrary(library: Object)` - Loads a [Drupal JS library](/nuxt/drupal-libraries) emitted by the backend
+
 #### Messages
 - `getMessages()` - Returns Drupal messages of the current page
 

--- a/content/5.nuxt/37.drupal-libraries.md
+++ b/content/5.nuxt/37.drupal-libraries.md
@@ -1,0 +1,45 @@
+---
+title: 'Drupal JS libraries'
+---
+
+## Overview
+
+Drupal emits the JavaScript libraries attached to a rendered form, block or component as `<drupal-library-*>` custom elements. See [Drupal JavaScript](/advanced-topics/drupal-javascript) for what the backend sends and why; this page covers loading them in Nuxt.
+
+## Rendering library elements
+
+Add a global `drupal-library--default.vue` component - the [default component](/nuxt/default-components) lookup resolves it for every `drupal-library-*` element, whatever library the backend attached. A reference implementation is part of the playground: [drupal-library--default.vue](https://github.com/drunomics/nuxtjs-drupal-ce/blob/2.x/playground/components/global/drupal-library--default.vue).
+
+The component is renderless: it takes the `library`, `js` and `drupalSettings` props of the element, hands them to `useDrupalCe().loadLibrary()` on mount, and renders nothing.
+
+```vue
+<script setup>
+const props = defineProps({ js: Array, drupalSettings: String })
+const { loadLibrary } = useDrupalCe()
+
+onMounted(() => loadLibrary({ js: props.js, drupalSettings: props.drupalSettings }))
+</script>
+```
+
+## loadLibrary()
+
+`useDrupalCe().loadLibrary(library)` takes a resolved library (`{ js, drupalSettings }`) and returns a promise settling once its files have loaded. On the server it resolves immediately - loading is a client-side concern.
+
+It lazy-loads the actual loader via a dynamic import, so the loader chunk - and the Drupal JavaScript it pulls in - is only fetched by pages that actually render a library element. The loader then:
+
+* resolves the file URLs against the configured `drupalBaseUrl`,
+* appends them as `<script>` tags, preserving execution order across all calls, so libraries load in the dependency order the backend resolved,
+* loads each URL only once, even when several libraries share a file,
+* merges `drupalSettings` into `window.drupalSettings` before any script runs,
+* calls `Drupal.attachBehaviors()` once the batch has loaded, so behaviours attach to the server-rendered markup,
+* skips a file that fails to load with a console warning, rather than aborting the batch.
+
+The `attributes` a library declares for its `<script>` tags are currently not applied.
+
+## Overriding or skipping a library
+
+To replace a library with a native implementation, add a component named after its element tag - `drupal-library-core-drupal-states.vue` for `core/drupal.states`. It takes precedence over the default component, so the library's JavaScript is never loaded. A component that renders nothing and does nothing skips the library entirely.
+
+## Trying it out
+
+The playground has a form whose conditional field is driven by `core/drupal.states` at [/form/states](https://github.com/drunomics/nuxtjs-drupal-ce/blob/2.x/playground/server/routes/ce-api/form/states.get.ts), served by a mock Custom Elements API response - a working example of the whole path, from the emitted elements to the attached behaviour.


### PR DESCRIPTION
Drupal attaches JavaScript libraries to the render arrays it converts to custom elements (form `#states`, autocomplete, module behaviours). Custom Elements now emits those as `<drupal-library-*>` elements next to the markup, but nothing on the docs site described it - and the Drupal forms page still listed form JavaScript as unavailable.

## Changes

- **New advanced topic [Drupal JavaScript](https://lupus-decoupled.org/advanced-topics/drupal-javascript)** (`3.advanced-topics/62.drupal-javascript.md`) - frontend-agnostic: what the backend emits and in which order, the element/prop shape with an example response, the seven things a frontend's library component has to do (renderless, resolve URLs, keep order, dedup, merge `drupalSettings`, `attachBehaviors`, skip failures), how to override or skip a single library, and the limitations (no CSS, `#states`-class behaviours only). Nuxt appears only as an example, linking on.
- **New Nuxt page [Drupal JS libraries](https://lupus-decoupled.org/nuxt/drupal-libraries)** (`5.nuxt/37.drupal-libraries.md`) - the `drupal-library--default.vue` default component, what `useDrupalCe().loadLibrary()` does and how it lazy-loads the loader chunk, overriding a single library, and the playground demo. `loadLibrary()` added to the composables list.
- **Drupal forms** - form JavaScript is emitted alongside the markup now, so the "Rendering forms in the frontend" paragraph and the webform limitations section are updated (CSS is still on the frontend, and Ajax/dialog-based elements still need frontend work).

The frontend-side companion PR trims the [nuxtjs-drupal-ce README section](https://github.com/drunomics/nuxtjs-drupal-ce/pull/526) to a brief pointer at these pages.

## Verified

- `npm run generate` builds green; `/advanced-topics/drupal-javascript` and `/nuxt/drupal-libraries` prerender, all internal links in the touched pages resolve to generated routes.
- Pages reviewed in a browser against the built site (nav placement, TOC, code blocks).
- `npm run lint` clean.

---
Drafted with Claude Code from the loki dev VM.